### PR TITLE
Add missing return

### DIFF
--- a/Assets/NatShare/Plugins/Managed/NatShareiOS.cs
+++ b/Assets/NatShare/Plugins/Managed/NatShareiOS.cs
@@ -32,6 +32,7 @@ namespace NatShareU.Platforms {
             if (!NatShareBridge.GetThumbnail(videoPath, time, ref pixelBuffer, ref width, ref height)) {
                 Debug.LogError("NatShare Error: Failed to get thumbnail for video at path: "+videoPath);
                 callback(null);
+		return;
             }
             var thumbnail = new Texture2D(width, height, TextureFormat.BGRA32, false);
             thumbnail.LoadRawTextureData(pixelBuffer, width * height * 4);


### PR DESCRIPTION
Add a return so that the does not crash when trying to load rawTextureData from an empty pixelBuffer.